### PR TITLE
Deal with potential memory leak in tornado AsyncHttpClient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado>=4.0
+tornado>=4.1
 futures
 PyYAML>=3.0
 six>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado>=4.1
+tornado>=4.1,<=4.3
 futures
 PyYAML>=3.0
 six>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado>=3.0.1,<4.2
+tornado>=4.0
 futures
 PyYAML>=3.0
 six>=1.4.0


### PR DESCRIPTION
As per the tornado docs,
http://www.tornadoweb.org/en/stable/releases/v4.0.0.html#tornado-httpclient
Tornado 4.0+ deals with a memory leak in AsyncHttpClient shutdown.

This is explained in:
https://github.com/tornadoweb/tornado/commit/8953e9beb1e376d9d907c77e61e0e628245de35d

For convenience:

Clients created without force_instance=True were never getting
GC'd because we were using the wrong reference for the async_clients
instance cache.

To guard against future errors, failure to remove an instance
from the cache when we expected to now raises an error instead of
failing silently.