### PR TITLE
Agent protocol (rebased on 0.9 instead of uber/master)

### DIFF
--- a/hacheck/agent_server.py
+++ b/hacheck/agent_server.py
@@ -1,0 +1,20 @@
+from . import spool
+
+from tornado.gen import coroutine
+from tornado.tcpserver import TCPServer
+
+
+class AgentServer(TCPServer):
+    def __init__(self, io_loop=None):
+        super(AgentServer, self).__init__(io_loop=io_loop)
+
+    @coroutine
+    def handle_stream(self, stream, address):
+        service_name = (yield stream.read_until(b'\n')).decode('utf-8').rstrip().split('/', 1)[0]
+        up, extra_info = spool.is_up(service_name)
+        if up:
+            yield stream.write('up\n'.encode('ascii'))
+        else:
+            yield stream.write('maint\n'.encode('ascii'))
+        stream.close()
+        return

--- a/hacheck/agent_server.py
+++ b/hacheck/agent_server.py
@@ -13,7 +13,7 @@ class AgentServer(TCPServer):
         service_name = (yield stream.read_until(b'\n')).decode('utf-8').rstrip().split('/', 1)[0]
         up, extra_info = spool.is_up(service_name)
         if up:
-            yield stream.write('up\n'.encode('ascii'))
+            yield stream.write('ready\n'.encode('ascii'))
         else:
             yield stream.write('maint\n'.encode('ascii'))
         stream.close()

--- a/hacheck/handlers.py
+++ b/hacheck/handlers.py
@@ -76,7 +76,11 @@ class BaseServiceHandler(tornado.web.RequestHandler):
             port = int(port)
             last_message = ""
             querystr = self.request.query
-            for this_checker in self.CHECKERS:
+            if self.settings['check_spool']:
+                checkers = [checker.check_spool] + self.CHECKERS
+            else:
+                checkers = self.CHECKERS
+            for this_checker in checkers:
                 code, message = yield this_checker(
                     service_name,
                     port,
@@ -103,16 +107,20 @@ class BaseServiceHandler(tornado.web.RequestHandler):
 
 
 class SpoolServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool]
+    CHECKERS = []
 
 
 class HTTPServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_http]
+    CHECKERS = [checker.check_http]
+
+
+class HaproxyServiceHandler(BaseServiceHandler):
+    CHECKERS = [checker.check_haproxy]
 
 
 class TCPServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_tcp]
+    CHECKERS = [checker.check_tcp]
 
 
 class MySQLServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_mysql]
+    CHECKERS = [checker.check_mysql]

--- a/hacheck/main.py
+++ b/hacheck/main.py
@@ -29,7 +29,7 @@ def log_request(handler):
                      handler._request_summary(), request_time)
 
 
-def get_app():
+def get_app(check_spool=True):
     return tornado.web.Application([
         (r'/http/([a-zA-Z0-9_-]+)/([0-9]+)/(.*)', handlers.HTTPServiceHandler),
         (r'/tcp/([a-zA-Z0-9_-]+)/([0-9]+)/?(.*)', handlers.TCPServiceHandler),
@@ -38,7 +38,7 @@ def get_app():
         (r'/recent', handlers.ListRecentHandler),
         (r'/status/count', handlers.ServiceCountHandler),
         (r'/status', handlers.StatusHandler),
-    ], start_time=time.time(), log_function=log_request)
+    ], start_time=time.time(), log_function=log_request, check_spool=check_spool)
 
 
 def setrlimit_nofile(soft_target):
@@ -94,6 +94,14 @@ def main():
         default=False,
         action='store_true'
     )
+    parser.add_option(
+        '-S',
+        '--no-check-spool-on-http',
+        dest='check_spool_on_http',
+        action='store_false',
+        default=True,
+        help='Do not include spool checks in results sent over HTTP (only makes sense when using an agent!'
+    )
     opts, args = parser.parse_args()
     if opts.config_file is not None:
         config.load_from(opts.config_file)
@@ -102,6 +110,9 @@ def main():
         opts.port = [3333]
     if config.config['rlimit_nofile'] is not None:
         setrlimit_nofile(config.config['rlimit_nofile'])
+
+    if not opts.check_spool_on_http and not opts.agent_port:
+        parser.error('Must pass -A and use an agent if disabling spool results on HTTP with -S')
 
     # set up logging
     log_path = config.config['log_path']
@@ -120,7 +131,7 @@ def main():
     # application stuff
     cache.configure(cache_time=config.config['cache_time'])
     spool.configure(spool_root=opts.spool_root)
-    application = get_app()
+    application = get_app(check_spool=opts.check_spool_on_http)
     ioloop = tornado.ioloop.IOLoop.instance()
     server = tornado.httpserver.HTTPServer(application, io_loop=ioloop)
 

--- a/hacheck/main.py
+++ b/hacheck/main.py
@@ -10,6 +10,7 @@ import tornado.httpserver
 import tornado.web
 from tornado.log import access_log
 
+from . import agent_server
 from . import cache
 from . import config
 from . import handlers
@@ -68,6 +69,15 @@ def main():
         help='Port to listen on. May be repeated. If not passed, defaults to :3333.'
     )
     parser.add_option(
+        '-A',
+        '--agent-port',
+        default=[],
+        type=int,
+        action='append',
+        help=('Port to listen on for agent checks. May be repeated. '
+              'If not passed, an agent listener will not be started. May be repeated.')
+    )
+    parser.add_option(
         '-B',
         '--bind-address',
         default='0.0.0.0',
@@ -113,6 +123,11 @@ def main():
     application = get_app()
     ioloop = tornado.ioloop.IOLoop.instance()
     server = tornado.httpserver.HTTPServer(application, io_loop=ioloop)
+
+    if opts.agent_port:
+        a_s = agent_server.AgentServer(io_loop=ioloop)
+        for port in opts.agent_port:
+            a_s.listen(port, opts.bind_address)
 
     if initialize_mutornadomon is not None:
         mutornadomon_collector = initialize_mutornadomon(application, io_loop=ioloop)

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -68,7 +68,7 @@ class AgentServerTestCase(tornado.testing.AsyncTestCase):
             stream.set_server_data(b'server\n')
             yield self.server.handle_stream(stream, None)
             response = stream.get_client_data()
-            self.assertEqual(response, b'up\n')
+            self.assertEqual(response, b'ready\n')
 
     @tornado.testing.gen_test
     def test_basic_down(self):

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -1,0 +1,80 @@
+import os
+
+from hacheck import agent_server
+from hacheck import spool
+
+import six
+import mock
+import tornado.concurrent
+import tornado.testing
+
+
+class StringIOStream(tornado.iostream.BaseIOStream):
+    def __init__(self, *args, **kwargs):
+        super(StringIOStream, self).__init__(*args, **kwargs)
+        # data from the server to the client
+        self.server_data = six.BytesIO()
+        # data from the client to the server
+        self.client_data = six.BytesIO()
+
+        self.client_offset_into_server_data = 0
+
+    def set_server_data(self, data):
+        self.server_data.write(data)
+
+    def get_client_data(self):
+        d = self.client_data.getvalue()
+        self.client_data = six.BytesIO()
+        return d
+
+    def read_until(self, delimiter):
+        rv = tornado.concurrent.Future()
+        response = six.BytesIO()
+        success = False
+        self.server_data.seek(self.client_offset_into_server_data)
+        while True:
+            c = self.server_data.read(1)
+            if not c:
+                break
+            response.write(c)
+            if c == delimiter:
+                rv.set_result(response.getvalue())
+                success = True
+                break
+        if success:
+            self.client_offset_info_server_data = self.server_data.tell()
+        self.server_data.seek(0, 2)
+        return rv
+
+    def write(self, data):
+        rv = tornado.concurrent.Future()
+        rv.set_result(None)
+        self.client_data.write(data)
+        return rv
+
+    def close(self):
+        pass
+
+
+class AgentServerTestCase(tornado.testing.AsyncTestCase):
+    def setUp(self):
+        super(AgentServerTestCase, self).setUp()
+        self.server = agent_server.AgentServer(io_loop=self.io_loop)
+
+    @tornado.testing.gen_test
+    def test_basic_up(self):
+        with mock.patch.object(spool, 'is_up', return_value=(True, {})):
+            stream = StringIOStream()
+            stream.set_server_data(b'server\n')
+            yield self.server.handle_stream(stream, None)
+            response = stream.get_client_data()
+            self.assertEqual(response, b'up\n')
+
+    @tornado.testing.gen_test
+    def test_basic_down(self):
+        with mock.patch.object(spool, 'is_up', return_value=(False, {'nope'})):
+            stream = StringIOStream()
+            stream.set_server_data(b'server\n')
+            yield self.server.handle_stream(stream, None)
+            response = stream.get_client_data()
+            self.assertEqual(response, b'maint\n')


### PR DESCRIPTION
Adds a server which speaks the [`agent-check`](https://cbonte.github.io/haproxy-dconv/configuration-1.6.html#5.2-agent-check) functionality present in HAProxy 1.6.x and uses that to represent spool information. When launched with `-S`, spool status will **only** be returned through the agent port, never through the main check port.

To disambiguate services, this expects HAproxy to be configured with the [`agent-send`](https://cbonte.github.io/haproxy-dconv/configuration-1.7.html#5.2-agent-send) option, which is in 1.7, but as a patch compiles cleanly against 1.6.x. Each server's `agent-send` should be configured to send the name of the backend.

This all seems a little hacky, but we're running it in production with great success (can easily disambiguate in logs between `hadown` causing a server to be removed and an actual failed healthcheck, and I anticipate adding support at some point for DRAIN mode).