### PR TITLE
Reads the host from X-Haproxy-Server-State, if present.

### DIFF
--- a/hacheck/checker.py
+++ b/hacheck/checker.py
@@ -19,7 +19,7 @@ TIMEOUT = 10
 
 # Do not cache spool checks
 @tornado.concurrent.return_future
-def check_spool(service_name, port, query, io_loop, callback, query_params, headers):
+def check_spool(service_name, host, port, query, io_loop, callback, query_params, headers):
     up, extra_info = spool.is_up(service_name, port=port)
     if not up:
         info_string = 'Service %s in down state' % (extra_info['service'],)
@@ -37,18 +37,18 @@ def check_spool(service_name, port, query, io_loop, callback, query_params, head
 # IMPORTANT: the gen.coroutine decorator needs to be the innermost
 @cache.cached
 @tornado.gen.coroutine
-def check_http(service_name, port, check_path, io_loop, query_params, headers):
-    return check_http_https(service_name, port, check_path, io_loop, query_params, headers, False)
+def check_http(service_name, host, port, check_path, io_loop, query_params, headers):
+    return check_http_https(service_name, host, port, check_path, io_loop, query_params, headers, False)
 
 
 # IMPORTANT: the gen.coroutine decorator needs to be the innermost
 @cache.cached
 @tornado.gen.coroutine
-def check_https(service_name, port, check_path, io_loop, query_params, headers):
-    return check_http_https(service_name, port, check_path, io_loop, query_params, headers, True)
+def check_https(service_name, host, port, check_path, io_loop, query_params, headers):
+    return check_http_https(service_name, host,  port, check_path, io_loop, query_params, headers, True)
 
 
-def check_http_https(service_name, port, check_path, io_loop, query_params, headers, ssl):
+def check_http_https(service_name, host,  port, check_path, io_loop, query_params, headers, ssl):
     if ssl:
         method = "https"
     else:
@@ -62,7 +62,7 @@ def check_http_https(service_name, port, check_path, io_loop, query_params, head
             headers_out[header] = headers[header]
     if config.config['service_name_header']:
         headers_out[config.config['service_name_header']] = service_name
-    path = '%s://127.0.0.1:%d%s%s' % (method, port, check_path, '?' + qp if qp else '')
+    path = '%s://%s:%d%s%s' % (method, host, port, check_path, '?' + qp if qp else '')
     request = tornado.httpclient.HTTPRequest(
         path,
         method='GET',
@@ -90,7 +90,7 @@ def check_http_https(service_name, port, check_path, io_loop, query_params, head
 
 @cache.cached
 @tornado.gen.coroutine
-def check_tcp(service_name, port, query, io_loop, query_params, headers):
+def check_tcp(service_name, host, port, query, io_loop, query_params, headers):
     stream = None
     connect_start = time.time()
 
@@ -99,7 +99,7 @@ def check_tcp(service_name, port, query, io_loop, query_params, headers):
         stream = tornado.iostream.IOStream(s, io_loop=io_loop)
         yield tornado.gen.with_timeout(
             datetime.timedelta(seconds=TIMEOUT),
-            tornado.gen.Task(stream.connect, ('127.0.0.1', port))
+            tornado.gen.Task(stream.connect, (host, port))
         )
 
     except tornado.gen.TimeoutError:
@@ -125,7 +125,7 @@ def check_tcp(service_name, port, query, io_loop, query_params, headers):
 
 @cache.cached
 @tornado.gen.coroutine
-def check_mysql(service_name, port, query, io_loop, query_params, headers):
+def check_mysql(service_name, host, port, query, io_loop, query_params, headers):
     username = config.config.get('mysql_username', None)
     password = config.config.get('mysql_password', None)
     if username is None or password is None:
@@ -144,7 +144,7 @@ def check_mysql(service_name, port, query, io_loop, query_params, headers):
 
 @cache.cached
 @tornado.gen.coroutine
-def check_smtp(service_name, port, query, io_loop, query_params, headers):
+def check_smtp(service_name, host, port, query, io_loop, query_params, headers):
     stream = None
     connect_start = time.time()
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
@@ -153,7 +153,7 @@ def check_smtp(service_name, port, query, io_loop, query_params, headers):
         yield tornado.gen.with_timeout(
             datetime.timedelta(seconds=TIMEOUT),
             tornado.gen.Task(
-                stream.connect, ('127.0.0.1', port))
+                stream.connect, (host, port))
         )
         yield stream.read_until(b'\r\n')
         yield stream.write(b'QUIT\r\n')

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -162,7 +162,7 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
             response = self.fetch('/http/foo/1/status', headers={'X-Haproxy-Server-State': server_state})
             self.assertEqual(200, response.code)
             args, _ = checker.call_args
-            assert args[1] = '1.2.3.4'
+            assert args[1] == '1.2.3.4'
             assert args[2] == 1234
 
     def test_old_haproxy_server_state_ignored(self):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -157,12 +157,13 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
         rv = tornado.concurrent.Future()
         rv.set_result((200, b'OK'))
         checker = mock.Mock(return_value=rv)
-        server_state = 'UP 2/3; addr=srv1; port=1234; name=bck/srv2; node=lb1; weight=1/2; scur=13/22; qcur=0'
+        server_state = 'UP 2/3; addr=srv1; host=1.2.3.4; port=1234; name=bck/srv2; node=lb1; weight=1/2; scur=13/22; qcur=0'
         with mock.patch.object(handlers.HTTPServiceHandler, 'CHECKERS', [checker]):
             response = self.fetch('/http/foo/1/status', headers={'X-Haproxy-Server-State': server_state})
             self.assertEqual(200, response.code)
             args, _ = checker.call_args
-            assert args[1] == 1234
+            assert args[1] = '1.2.3.4'
+            assert args[2] == 1234
 
     def test_old_haproxy_server_state_ignored(self):
         rv = tornado.concurrent.Future()


### PR DESCRIPTION
Most of the time, the service we are healthchecking runs on 127.0.0.1, as hacheck assumes. However, if we provide a host in the X-Haproxy-Server-State header, we should try healthchecking there, instead. This will be necessary for when we proxy from HAProxy directly to Smartstack, as Smartstack does not listen on localhost and so currently hacheck cannot find it and returns 503.