### PR TITLE
Don't use the service name as part of the cache key.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 matrix:
   include:
-    - python: "2.6"
     - python: "2.7"
     - python: "3.4"
     - python: "3.5"
-    - python: "3.5"
+    - python: "3.6"
     - python: "2.7"
       env: BUILD_PKG=true
       sudo: required

--- a/hacheck/cache.py
+++ b/hacheck/cache.py
@@ -4,7 +4,7 @@ import functools
 import time
 try:
     from collections import Counter
-except:
+except Exception:
     from .compat import Counter
 from collections import namedtuple
 
@@ -91,7 +91,10 @@ def cached(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         now = time.time()
-        key = tuple([func.__name__, args])
+        # To avoid duplicate healthchecks for one instance advertised on multiple namespaces,
+        # drop the first positional arg, which is service name, from the cache key.
+        # That leaves port, which still uniquely identifies an instance, and path.
+        key = tuple([func.__name__, args[1:]])
         try:
             response = getv(key, now)
         except KeyError:

--- a/hacheck/cache.py
+++ b/hacheck/cache.py
@@ -8,6 +8,8 @@ except Exception:
     from .compat import Counter
 from collections import namedtuple
 
+from . import config as configuration
+
 _cache = {}
 
 config = {
@@ -32,6 +34,9 @@ Record = namedtuple('Record', ['expiry', 'value'])
 def configure(cache_time=config['cache_time']):
     """Configure the cache and reset its values"""
     config['cache_time'] = cache_time
+    # We no longer use service name as part of the cache key.
+    # If we want the service name to be part of the response header, we can't use the cache.
+    config['ignore_cache'] = configuration.config.get('service_name_header') is not None
     stats.clear()
     stats.update(default_stats)
     _cache.clear()

--- a/hacheck/compat.py
+++ b/hacheck/compat.py
@@ -37,7 +37,7 @@ def nested3(*managers):
             vars.append(enter())
             exits.append(exit)
         yield vars
-    except:
+    except Exception:
         exc = sys.exc_info()
     finally:
         while exits:
@@ -45,7 +45,7 @@ def nested3(*managers):
             try:
                 if exit(*exc):
                     exc = (None, None, None)
-            except:
+            except Exception:
                 exc = sys.exc_info()
         if exc != (None, None, None):
             # Don't rely on sys.exc_info() still containing

--- a/hacheck/haupdown.py
+++ b/hacheck/haupdown.py
@@ -107,7 +107,7 @@ def main(default_action='list'):
                 unix_username = line.split('#')[0].strip()
                 if unix_username:
                     nonhumans.add(unix_username)
-    except:
+    except Exception:
         pass
     if opts.action == 'down' and not opts.reason:
         if 'SUDO_USER' in os.environ:

--- a/hacheck/main.py
+++ b/hacheck/main.py
@@ -24,6 +24,8 @@ except ImportError:
 
 class DummyTimeout(object):
     callback = None
+
+
 DUMMY = DummyTimeout()
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -10,6 +10,7 @@ import tornado.concurrent
 import tornado.web
 import tornado.testing
 
+from hacheck import cache
 from hacheck import checker
 from hacheck import config
 from hacheck import spool
@@ -117,6 +118,17 @@ class BaseTestHTTPHTTPSChecker(object):
             code, response = yield self.check_http_https('service_name', self.get_http_port(), "/sname",
                                                          io_loop=self.io_loop, query_params="", headers={})
             self.assertEqual(b'service_name', response)
+
+    @tornado.testing.gen_test
+    def test_cache_hit_different_registration(self):
+        with mock.patch.dict(config.config, {'service_name_header': 'SName'}):
+            cache.stats.clear()
+            code_1, response_1 = yield self.check_http_https('service_name.main', self.get_http_port(), "/sname",
+                                                             io_loop=self.io_loop, query_params="", headers={})
+            code_2, response_2 = yield self.check_http_https('service_name.main_ro', self.get_http_port(), "/sname",
+                                                             io_loop=self.io_loop, query_params="", headers={})
+            self.assertEqual(cache.stats['gets'], 2)
+            self.assertEqual(cache.stats['hits'], 1)
 
     @tornado.testing.gen_test
     def test_query_params_passed(self):

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -121,25 +121,24 @@ class BaseTestHTTPHTTPSChecker(object):
 
     @tornado.testing.gen_test
     def test_cache_ignores_service_name(self):
-        cache.configure()
-        code_1, response_1 = yield self.check_http_https('service_name.main', self.get_http_port(), "/sname",
+        cache.stats.clear()
+        code_1, response_1 = yield self.check_http_https('service_name.main', self.get_http_port(), "/",
                                                          io_loop=self.io_loop, query_params="", headers={})
-        code_2, response_2 = yield self.check_http_https('service_name.main_ro', self.get_http_port(), "/sname",
+        code_2, response_2 = yield self.check_http_https('service_name.main_ro', self.get_http_port(), "/",
                                                          io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(cache.stats['gets'], 2)
         self.assertEqual(cache.stats['hits'], 1)
 
     @tornado.testing.gen_test
     def test_service_name_header_disables_cache(self):
+        cache.stats.clear()
         with mock.patch.dict(config.config, {'service_name_header': 'SName'}):
-            cache.configure()
             code_1, response_1 = yield self.check_http_https('service_name.main', self.get_http_port(), "/sname",
                                                              io_loop=self.io_loop, query_params="", headers={})
             code_2, response_2 = yield self.check_http_https('service_name.main_ro', self.get_http_port(), "/sname",
                                                              io_loop=self.io_loop, query_params="", headers={})
             self.assertEqual(cache.stats['gets'], 2)
             self.assertEqual(cache.stats['hits'], 0)
-        cache.configure()
 
     @tornado.testing.gen_test
     def test_query_params_passed(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
-envlist = py{26,27,33,34,35}-{tornado41,tornado43,flake}
+envlist = py{27,34,35,36}-{tornado41,tornado43,flake}, py{34,35,36}-{tornado50}
 
 [testenv]
 usedevelop=True
 basepython =
-	py26: python2.6
 	py27: python2.7
-	py33: python3.3
 	py34: python3.4
 	py35: python3.5
+	py36: python3.6
 install_command = pip install --upgrade {opts} {packages}
 deps =
 	tornado41,tornado43: -rrequirements-tests.txt
 	tornado41: tornado==4.1.0
 	tornado43: tornado==4.3.0
-	py{26,27}: -rrequirements-py2.txt
+	tornado50: tornado==5.0.2
+	py27: -rrequirements-py2.txt
 	flake: flake8
     docker-compose==1.4
 commands =


### PR DESCRIPTION
A single instance on localhost is still uniquely identifiable by its port, so this will offload many requests for service/instances registered on more than one namespace (e.g., `main` and `main_ro`).

Also updated versions of things to newer in `tox.ini`, and cleaned up some `flake` issues.