### PR TITLE
Kubernetes compatibility changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ This version has several features not present in the upstream version:
   This is useful if there is some software, like [Paasta](github.com/Yelp/paasta), making decisions centrally about when
   to kill tasks.
 * If the client sends the header `X-Haproxy-Server-State`, then we use the port specified in that header and ignore the
-  port in the URL.
+  port in the URL. We also use the host address specified in this header instead of localhost.
   This is useful for configurations where an HAProxy has a backend with many servers running on different ports, such
-  as when your tasks are running under [Marathon](github.com/mesosphere/marathon).
+  as when your tasks are running under [Marathon](github.com/mesosphere/marathon). Or if the backends have different
+  IPs such as Pods running on Kubernetes.
+* If the client sends `X-Nerve-Check-IP`, then we use the IP specified here to check against (rather than the default
+  of localhost). This is again useful for Kubernetes Pods where we want to healthcheck with [Nerve](github.com/airbnb/nerve)
+  from the hosts network namespace but each Pod runs with its own IP.
 * Spool files(downtimes) can optionally have expirations, and store information about when they were created.
 * Spool files(downtimes) can apply to a service on a specific port - useful if you have multiple copies of a service on
   the same box.

--- a/hacheck/checker.py
+++ b/hacheck/checker.py
@@ -20,7 +20,7 @@ TIMEOUT = 10
 # Do not cache spool checks
 @tornado.concurrent.return_future
 def check_spool(service_name, port, query, host, io_loop, callback, query_params, headers):
-    up, extra_info = spool.is_up(service_name, port=port)
+    up, extra_info = spool.is_up(service_name, port=port, host=host)
     if not up:
         info_string = 'Service %s in down state' % (extra_info['service'],)
         if extra_info.get('creation') is not None:

--- a/hacheck/handlers.py
+++ b/hacheck/handlers.py
@@ -111,7 +111,10 @@ class BaseServiceHandler(tornado.web.RequestHandler):
         header_port, header_host = self.maybe_get_host_port_from_haproxy_server_state()
         if not header_host:
             header_host = self.maybe_get_host_from_nerve_header()
-        host = header_host if header_host else '127.0.0.1'
+        if header_host and header_host != self.settings['host_ip']:
+            host = header_host
+        else:
+            host = '127.0.0.1'
         port = header_port if header_port else port
 
         seen_services[service_name] = time.time()

--- a/hacheck/handlers.py
+++ b/hacheck/handlers.py
@@ -94,7 +94,6 @@ class BaseServiceHandler(tornado.web.RequestHandler):
         parts = [part for part in parts if len(part) == 2]
 
         state = dict(parts)
-        print(state)
         return state.get('port'), state.get('address')
 
     def maybe_get_host_from_nerve_header(self):

--- a/hacheck/main.py
+++ b/hacheck/main.py
@@ -3,6 +3,7 @@ import optparse
 import signal
 import time
 import types
+import socket
 import sys
 import resource
 
@@ -37,6 +38,7 @@ def log_request(handler):
 
 
 def get_app():
+    host_ip = socket.gethostbyname(socket.gethostname())
     return tornado.web.Application([
         (r'/http/([.a-zA-Z0-9_-]+)/([0-9]+)/(.*)', handlers.HTTPServiceHandler),
         (r'/https/([.a-zA-Z0-9_-]+)/([0-9]+)/(.*)', handlers.HTTPSServiceHandler),
@@ -47,7 +49,7 @@ def get_app():
         (r'/recent', handlers.ListRecentHandler),
         (r'/status/count', handlers.ServiceCountHandler),
         (r'/status', handlers.StatusHandler),
-    ], start_time=time.time(), log_function=log_request)
+    ], start_time=time.time(), log_function=log_request, host_ip=host_ip)
 
 
 def remove_timeout(self, timeout):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -88,7 +88,7 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
         ):
             response = self.fetch('/spool/foo/1/status')
             self.assertEqual(response.code, 503)
-            self.assertRegexpMatches(response.body, b'^Service any in down state since 4\.0+ until 5\.0+: reason$')  # noqa
+            self.assertRegexpMatches(response.body, b'^Service any in down state since 4\\.0+ until 5\\.0+: reason$')
 
     def test_calls_all_checkers(self):
         rv1 = tornado.concurrent.Future()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -101,8 +101,12 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
             response = self.fetch('/spool/foo/1/status')
             self.assertEqual(200, response.code)
             self.assertEqual(b'OK2', response.body)
-            checker1.assert_called_once_with('foo', 1, 'status', io_loop=mock.ANY, query_params='', headers=mock.ANY)
-            checker2.assert_called_once_with('foo', 1, 'status', io_loop=mock.ANY, query_params='', headers=mock.ANY)
+            checker1.assert_called_once_with(
+                'foo', 1, 'status', '127.0.0.1', io_loop=mock.ANY, query_params='', headers=mock.ANY
+            )
+            checker2.assert_called_once_with(
+                'foo', 1, 'status', '127.0.0.1', io_loop=mock.ANY, query_params='', headers=mock.ANY
+            )
 
     def test_passes_headers(self):
         rv1 = tornado.concurrent.Future()
@@ -112,7 +116,7 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
             response = self.fetch('/spool/foo/1/status')
             self.assertEqual(200, response.code)
             checker1.assert_called_with(
-                'foo', 1, 'status', io_loop=mock.ANY, query_params='',
+                'foo', 1, 'status', '127.0.0.1', io_loop=mock.ANY, query_params='',
                 headers={
                     'Connection': 'close',
                     'Host': mock.ANY,
@@ -157,12 +161,24 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
         rv = tornado.concurrent.Future()
         rv.set_result((200, b'OK'))
         checker = mock.Mock(return_value=rv)
-        server_state = 'UP 2/3; addr=srv1; port=1234; name=bck/srv2; node=lb1; weight=1/2; scur=13/22; qcur=0'
+        server_state = 'UP 2/3; address=srv1; port=1234; name=bck/srv2; node=lb1; weight=1/2; scur=13/22; qcur=0'
         with mock.patch.object(handlers.HTTPServiceHandler, 'CHECKERS', [checker]):
             response = self.fetch('/http/foo/1/status', headers={'X-Haproxy-Server-State': server_state})
             self.assertEqual(200, response.code)
             args, _ = checker.call_args
             assert args[1] == 1234
+            assert args[3] == 'srv1'
+
+    def test_nerve_header(self):
+        rv = tornado.concurrent.Future()
+        rv.set_result((200, b'OK'))
+        checker = mock.Mock(return_value=rv)
+        with mock.patch.object(handlers.HTTPServiceHandler, 'CHECKERS', [checker]):
+            response = self.fetch('/http/foo/1/status', headers={'X-Nerve-Check-IP': '10.1.1.1'})
+            self.assertEqual(200, response.code)
+            args, _ = checker.call_args
+            assert args[1] == 1
+            assert args[3] == '10.1.1.1'
 
     def test_old_haproxy_server_state_ignored(self):
         rv = tornado.concurrent.Future()
@@ -174,6 +190,7 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
             self.assertEqual(200, response.code)
             args, _ = checker.call_args
             assert args[1] == 1
+            assert args[3] == '127.0.0.1'
 
     def test_option_parsing(self):
         with nested(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -88,7 +88,7 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
         ):
             response = self.fetch('/spool/foo/1/status')
             self.assertEqual(response.code, 503)
-            self.assertRegexpMatches(response.body, b'^Service any in down state since 4\.0+ until 5\.0+: reason$')
+            self.assertRegexpMatches(response.body, b'^Service any in down state since 4\.0+ until 5\.0+: reason$')  # noqa
 
     def test_calls_all_checkers(self):
         rv1 = tornado.concurrent.Future()

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -55,7 +55,7 @@ class EchoParamFoo(tornado.web.RequestHandler):
 class TestChecker(TestCase):
     def test_spool_success(self):
         with mock.patch.object(spool, 'is_up', return_value=(True, {})) as is_up_patch:
-            fut = checker.check_spool(se.name, se.port, se.query, None, query_params=None, headers={})
+            fut = checker.check_spool(se.name, se.port, se.query, '127.0.0.1', None, query_params=None, headers={})
             self.assertIsInstance(fut, tornado.concurrent.Future)
             self.assertTrue(fut.done())
             res = fut.result()
@@ -64,7 +64,7 @@ class TestChecker(TestCase):
 
     def test_spool_failure(self):
         with mock.patch.object(spool, 'is_up', return_value=(False, {'service': se.service})) as is_up_patch:
-            fut = checker.check_spool(se.name, se.port, se.query, None, query_params=None, headers={})
+            fut = checker.check_spool(se.name, se.port, se.query, '127.0.0.1', None, query_params=None, headers={})
             self.assertEqual(fut.result()[0], 503)
             is_up_patch.assert_called_once_with(se.name, port=se.port)
 
@@ -84,47 +84,47 @@ class BaseTestHTTPHTTPSChecker(object):
 
     @tornado.testing.gen_test
     def test_check_success(self):
-        response = yield self.check_http_https("foo", self.get_http_port(), "/", io_loop=self.io_loop, query_params="",
-                                               headers={})
+        response = yield self.check_http_https("foo", self.get_http_port(), "/", '127.0.0.1', io_loop=self.io_loop,
+                                               query_params="", headers={})
         self.assertEqual((200, b'TEST OK'), response)
 
     @tornado.testing.gen_test
     def test_check_failure(self):
-        code, response = yield self.check_http_https("foo", self.get_http_port(), "/bar", io_loop=self.io_loop,
-                                                     query_params="", headers={})
+        code, response = yield self.check_http_https("foo", self.get_http_port(), "/bar", '127.0.0.1',
+                                                     io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(404, code)
 
     @tornado.testing.gen_test
     def test_check_redirect(self):
-        code, response = yield self.check_http_https("foo", self.get_http_port(), "/redirect", io_loop=self.io_loop,
-                                                     query_params="", headers={})
+        code, response = yield self.check_http_https("foo", self.get_http_port(), "/redirect", '127.0.0.1',
+                                                     io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(301, code)
 
     @tornado.testing.gen_test
     def test_check_failure_with_code(self):
-        code, response = yield self.check_http_https("foo", self.get_http_port(), "/bip", io_loop=self.io_loop,
-                                                     query_params="", headers={})
+        code, response = yield self.check_http_https("foo", self.get_http_port(), "/bip", '127.0.0.1',
+                                                     io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(501, code)
 
     @tornado.testing.gen_test
     def test_check_wrong_port(self):
-        code, response = yield self.check_http_https("foo", self.get_http_port() + 1, "/", io_loop=self.io_loop,
-                                                     query_params="", headers={})
+        code, response = yield self.check_http_https("foo", self.get_http_port() + 1, "/", '127.0.0.1',
+                                                     io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(599, code)
 
     @tornado.testing.gen_test
     def test_service_name_header(self):
         with mock.patch.dict(config.config, {'service_name_header': 'SName'}):
-            code, response = yield self.check_http_https('service_name', self.get_http_port(), "/sname",
+            code, response = yield self.check_http_https('service_name', self.get_http_port(), "/sname", '127.0.0.1',
                                                          io_loop=self.io_loop, query_params="", headers={})
             self.assertEqual(b'service_name', response)
 
     @tornado.testing.gen_test
     def test_cache_ignores_service_name(self):
         cache.stats.clear()
-        code_1, response_1 = yield self.check_http_https('service_name.main', self.get_http_port(), "/",
+        code_1, response_1 = yield self.check_http_https('service_name.main', self.get_http_port(), "/", '127.0.0.1',
                                                          io_loop=self.io_loop, query_params="", headers={})
-        code_2, response_2 = yield self.check_http_https('service_name.main_ro', self.get_http_port(), "/",
+        code_2, response_2 = yield self.check_http_https('service_name.main_ro', self.get_http_port(), "/", '127.0.0.1',
                                                          io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(cache.stats['gets'], 2)
         self.assertEqual(cache.stats['hits'], 1)
@@ -134,22 +134,24 @@ class BaseTestHTTPHTTPSChecker(object):
         cache.stats.clear()
         with mock.patch.dict(config.config, {'service_name_header': 'SName'}):
             code_1, response_1 = yield self.check_http_https('service_name.main', self.get_http_port(), "/sname",
-                                                             io_loop=self.io_loop, query_params="", headers={})
+                                                             '127.0.0.1', io_loop=self.io_loop, query_params="",
+                                                             headers={})
             code_2, response_2 = yield self.check_http_https('service_name.main_ro', self.get_http_port(), "/sname",
-                                                             io_loop=self.io_loop, query_params="", headers={})
+                                                             '127.0.0.1', io_loop=self.io_loop, query_params="",
+                                                             headers={})
             self.assertEqual(cache.stats['gets'], 2)
             self.assertEqual(cache.stats['hits'], 0)
 
     @tornado.testing.gen_test
     def test_query_params_passed(self):
-        response = yield self.check_http_https("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop,
-                                               query_params="foo=bar", headers={})
+        response = yield self.check_http_https("foo", self.get_http_port(), "/echo_foo", '127.0.0.1',
+                                               io_loop=self.io_loop, query_params="foo=bar", headers={})
         self.assertEqual((200, b'bar'), response)
 
     @tornado.testing.gen_test
     def test_query_params_not_passed(self):
-        response = yield self.check_http_https("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop,
-                                               query_params="", headers={})
+        response = yield self.check_http_https("foo", self.get_http_port(), "/echo_foo", '127.0.0.1',
+                                               io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(400, response[0])
 
 
@@ -192,14 +194,15 @@ class TestTCPChecker(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_check_success(self):
-        response = yield checker.check_tcp("foo", self.port, None, io_loop=self.io_loop, query_params="", headers={})
+        response = yield checker.check_tcp("foo", self.port, None, '127.0.0.1',
+                                           io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(200, response[0])
 
     @tornado.testing.gen_test
     def test_check_failure(self):
         with mock.patch.object(checker, 'TIMEOUT', 1):
-            response = yield checker.check_tcp("foo", self.unlistened_port, None, io_loop=self.io_loop, query_params="",
-                                               headers={})
+            response = yield checker.check_tcp("foo", self.unlistened_port, None, '127.0.0.1',
+                                               io_loop=self.io_loop, query_params="", headers={})
             self.assertEqual(response[0], 503)
 
 
@@ -238,12 +241,13 @@ class TestSMTPChecker(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_check_success(self):
-        response = yield checker.check_smtp("foo", self.port, None, io_loop=self.io_loop, query_params="", headers={})
+        response = yield checker.check_smtp("foo", self.port, None, '127.0.0.1',
+                                            io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(200, response[0])
 
     @tornado.testing.gen_test
     def test_check_failure(self):
         with mock.patch.object(self.server, 'never_respond', True):
-            response = yield checker.check_smtp("foo", self.port, None, io_loop=self.io_loop, query_params="",
-                                                headers={})
+            response = yield checker.check_smtp("foo", self.port, None, '127.0.0.1',
+                                                io_loop=self.io_loop, query_params="", headers={})
             self.assertEqual((503, 'Peer unexpectedly closed connection'), response)

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -60,13 +60,13 @@ class TestChecker(TestCase):
             self.assertTrue(fut.done())
             res = fut.result()
             self.assertEqual(res[0], 200)
-            is_up_patch.assert_called_once_with(se.name, port=se.port)
+            is_up_patch.assert_called_once_with(se.name, port=se.port, host='127.0.0.1')
 
     def test_spool_failure(self):
         with mock.patch.object(spool, 'is_up', return_value=(False, {'service': se.service})) as is_up_patch:
             fut = checker.check_spool(se.name, se.port, se.query, '127.0.0.1', None, query_params=None, headers={})
             self.assertEqual(fut.result()[0], 503)
-            is_up_patch.assert_called_once_with(se.name, port=se.port)
+            is_up_patch.assert_called_once_with(se.name, port=se.port, host='127.0.0.1')
 
 
 class BaseTestHTTPHTTPSChecker(object):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,7 +68,7 @@ class TestIntegration(tornado.testing.AsyncHTTPTestCase):
         hacheck.spool.down('test_app', 'TESTING')
         response = self.fetch('/http/test_app/%d/pinged' % self.get_http_port())
         self.assertEqual(503, response.code)
-        self.assertRegexpMatches(response.body, b'^Service test_app in down state since (\d|\.)*: TESTING$')  # noqa
+        self.assertRegexpMatches(response.body, b'^Service test_app in down state since (\\d|\\.)*: TESTING$')
         hacheck.spool.up('test_app')
         response = self.fetch('/http/test_app/%d/pinged' % self.get_http_port())
         self.assertEqual(b'PONG', response.body)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,7 +68,7 @@ class TestIntegration(tornado.testing.AsyncHTTPTestCase):
         hacheck.spool.down('test_app', 'TESTING')
         response = self.fetch('/http/test_app/%d/pinged' % self.get_http_port())
         self.assertEqual(503, response.code)
-        self.assertRegexpMatches(response.body, b'^Service test_app in down state since (\d|\.)*: TESTING$')
+        self.assertRegexpMatches(response.body, b'^Service test_app in down state since (\d|\.)*: TESTING$')  # noqa
         hacheck.spool.up('test_app')
         response = self.fetch('/http/test_app/%d/pinged' % self.get_http_port())
         self.assertEqual(b'PONG', response.body)


### PR DESCRIPTION
Make hacheck look for host in headers

This makes it possible to override the host to check from two
headers:
 * X-Haproxy-Server-State which is sent by HAProxy and we already use to
override the check port
 * X-Nerve-Check-IP which I am going to configure Nerve to send

The default is to fallback to checking localhost as we do now. The
motivation for this change is that Kubernetes Pods get their own IP. So
we currently have to run hacheck in a sidecar for every service we run
since hacheck currently hardcodes checking localhost. With this change
we can configure Nerve to send this new header and use 1 system hacheck
for all the Pods on a host.

related: https://github.com/Yelp/paasta/pull/2133