### PR TITLE
Add static build of haupdown

### DIFF
--- a/build_static.sh
+++ b/build_static.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This builds a statically linked binary for haupdown that
+# has python and virtualenv etc. all in one binary. This is
+# useful since we can in theory volume mount this binary
+# into any docker container and run it, reducing the need
+# for sidecars to run hacheck.
+set -eu
+rm -rf /work/hacheck/static
+virtualenv -p python3.6 /static
+set +u
+source /static/bin/activate
+set -u
+pip install -r /work/requirements.txt
+pip install pyinstaller staticx patchelf-wrapper
+pyinstaller --onefile /work/hacheck/haupdown.py --distpath /work/hacheck/static/
+staticx /work/hacheck/static/haupdown /work/hacheck/static/haupdown_static
+rm -f /work/hacheck/static/haupdown && mv /work/hacheck/static/haupdown_static /work/hacheck/static/haupdown

--- a/debian/hacheck.links
+++ b/debian/hacheck.links
@@ -4,3 +4,4 @@ usr/share/python/hacheck/bin/halist usr/bin/halist
 usr/share/python/hacheck/bin/hashowdowned usr/bin/hashowdowned
 usr/share/python/hacheck/bin/hastatus usr/bin/hastatus
 usr/share/python/hacheck/bin/haup usr/bin/haup
+usr/share/python/hacheck/lib/python2.7/site-packages/hacheck/static/haupdown usr/bin/haupdown_static

--- a/debian/rules
+++ b/debian/rules
@@ -18,4 +18,5 @@ override_dh_auto_test:
 	true
 
 override_dh_virtualenv:
+	/bin/bash /work/build_static.sh
 	dh_virtualenv --extra-index-url 'https://pypi.yelpcorp.com/simple' --python=/usr/bin/python2.7 --no-test

--- a/dockerfiles/xenial/Dockerfile
+++ b/dockerfiles/xenial/Dockerfile
@@ -1,7 +1,11 @@
 FROM ubuntu:xenial
 
+RUN apt-get update > /dev/null && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa
+
 RUN apt-get update && apt-get -y install dpkg-dev python-tox python-setuptools \
-  python-dev debhelper python-yaml libyaml-dev git wget
+  python-dev debhelper python-yaml libyaml-dev git wget patchelf python3.6-dev
 
 RUN cd `mktemp -d` && wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_0.11-1_all.deb && dpkg -i dh-virtualenv_0.11-1_all.deb && apt-get -f install
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     keywords=["monitoring", "load-balancing", "networking"],
     description="HAProxy health-check proxying service",
+    package_data={'hacheck': ['static/*']},
     install_requires=[
         'tornado>=4.1,<=4.3',
         'PyYAML>=3.0',


### PR DESCRIPTION
This is kinda nuts so apologies...

I'm trying to build a statically linked binary version of haupdown that
I can run anywhere. For example, in a kubernetes service container via a
volume mount to the binary on the host. This way kubernetes container
hooks can call haupdown without needing hacheck in the service container
or in a sidecar.

Any suggestions on a cleaner way to achieve that are welcomed, this was
just the first thing I tried that worked.

Tested with `make itest_xenial` installing it on a host and hadowning from an alpine container:  `sudo docker run -v /var/spool/hacheck/:/var/spool/hacheck -v /usr/bin/haupdown_static:/haupdown -ti alpine /haupdown -a down -P 31978 -r mmb example_happyhour.main`