### PR TITLE
Only bother running tests on python 3.6 and tornado 4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ env32/
 env33/
 .tox/
 bintray.json
+debian/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
 language: python
-matrix:
-  include:
-    - python: "2.7"
-    - python: "3.4"
-    - python: "3.5"
-    - python: "3.6"
-    - python: "2.7"
-      env: BUILD_PKG=true
-      sudo: required
-      services:
-        - docker
-  fast_finish: true
+python:
+    - "3.6"
+sudo: required
+services:
+   - docker
 install:
   - pip install tox
 # only build master and PRs, not every branch
@@ -18,7 +11,7 @@ branches:
   only:
   - master
   - /^v[0-9.].*$/
-script: PY=py${TRAVIS_PYTHON_VERSION/./}; if [[ -n "$BUILD_PKG" ]]; then make "itest_trusty"; else tox -e ${PY}-tornado41,${PY}-tornado43,${PY}-flake; fi;
+script: tox && make itest_xenial
 deploy:
   - provider: bintray
     file: "bintray.json"
@@ -27,5 +20,4 @@ deploy:
       secure: "XXYKkbrtGfpwyvYFR9IIozIzAAz+v1eEjzgI23OOiM11wrr7eQ79urieWuiW1KzkiGM/Pq/TRKA2WyOCFp04S6PQUIMSsD56Cic8HliDxkLrh7AdptOvoOvGiFjzz2+ubo/Me6+JVWG0lwCBeC3oos/rT0KeWp+LJ6sYol+FdUdPSTemv7dvdH7LbWePsQJNAJd66psFcaOLAlySdXM85SVOJU70+IFMduIUHvGzexzCTJTMMqssn/gKyB8lqKu5ab+NbFWy/dEDMMTL2QMkH1FdBAJBYxpV6OfBxbCN4n9PIl1Op+UGVK5g+5v0QuJ75TtOCzJdpKdJO0TQma8XB7Gq0AWZrMsCx76Ws5dAym4wxtXbeG/S7viHhqEBxoOQW1YV30VV/tCWD7qnnjy48zDgTqoSv2XvDX4ch1LoySZ7yBAfIv6nR9ktciGloOIW4vx3uAKuhDkVdabH2DC2sqYHShLQJ+OPEE+KI8C6QPFrE+8cK21PAA3/9+4lCV1S16nYH5Q63czYciodW6TBTKVNFkyIfawbe7VLk/87uLYQROWvZoJOv+OOu00XEdFbRMF5ooqCDQ9+FQ8tYOfFkoMep7OBL+5n6NlwezoIX11RcStYgiQWcuXlUftk4AbtAplaxHKEXNIHJhApY69b8gzQSruxmSV8ZI6efolXzXQ="
     on:
       tags: true
-      condition: $BUILD_PKG == true
       repo: Yelp/hacheck

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,1 +1,0 @@
-unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -1,38 +1,20 @@
 [tox]
-envlist = py{27,34,35,36}-{tornado41,tornado43,flake}, py{34,35,36}-{tornado50}
+envlist = py36
 
 [testenv]
 usedevelop=True
-basepython =
-	py27: python2.7
-	py34: python3.4
-	py35: python3.5
-	py36: python3.6
+basepython = python3.6
 install_command = pip install --upgrade {opts} {packages}
 deps =
-	tornado41,tornado43: -rrequirements-tests.txt
-	tornado41: tornado==4.1.0
-	tornado43: tornado==4.3.0
-	tornado50: tornado==5.0.2
-	py27: -rrequirements-py2.txt
-	flake: flake8
-    docker-compose==1.4
+    -rrequirements-tests.txt
+    flake8
+    docker-compose==1.24.1
 commands =
-	flake: flake8 hacheck tests
-	tornado41,tornado43: nosetests
-
-[testenv:package_lucid]
-basepython = python2.7
-setenv =
-    COMPOSE_FILE = dockerfiles/lucid/docker-compose.yml
-commands =
-    docker-compose build
-    docker-compose run lucid
-    docker-compose stop
-    docker-compose rm --force
+	flake8 hacheck tests
+	nosetests
 
 [testenv:package_trusty]
-basepython = python2.7
+basepython = python3.6
 setenv =
     COMPOSE_FILE = dockerfiles/trusty/docker-compose.yml
 commands =
@@ -42,7 +24,7 @@ commands =
     docker-compose rm --force
 
 [testenv:package_xenial]
-basepython = python2.7
+basepython = python3.6
 setenv =
     COMPOSE_FILE = dockerfiles/xenial/docker-compose.yml
 commands =
@@ -51,18 +33,8 @@ commands =
     docker-compose stop
     docker-compose rm --force
 
-[testenv:itest_lucid]
-basepython = python2.7
-setenv =
-    COMPOSE_FILE = dockerfiles/itest/itest_lucid/docker-compose.yml
-commands =
-    docker-compose build
-    docker-compose run itest
-    docker-compose stop
-    docker-compose rm --force
-
 [testenv:itest_trusty]
-basepython = python2.7
+basepython = python3.6
 setenv =
     COMPOSE_FILE = dockerfiles/itest/itest_trusty/docker-compose.yml
 commands =
@@ -72,7 +44,7 @@ commands =
     docker-compose rm --force
 
 [testenv:itest_xenial]
-basepython = python2.7
+basepython = python3.6
 setenv =
     COMPOSE_FILE = dockerfiles/itest/itest_xenial/docker-compose.yml
 commands =


### PR DESCRIPTION
This is our fork, we can do what we want.

Let's start by greatly simplifying the build / test. Then I would like to upgrade tornado in "one" place.