### PR TITLE
support 204 responses from proxied services

### DIFF
--- a/hacheck/handlers.py
+++ b/hacheck/handlers.py
@@ -140,7 +140,12 @@ class BaseServiceHandler(tornado.web.RequestHandler):
                         self.set_status(code)
                     else:
                         self.set_status(503)
-                    self.write(message)
+
+                    # tornado will complain if we try to write anything (even
+                    # an empty string) with an HTTP 204 (No Content)
+                    if len(message) > 0:
+                        self.write(message)
+
                     self.finish()
                     break
             else:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -159,6 +159,14 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
             response = self.fetch('/http/uncached-weird-code/80/status')
             self.assertEqual(503, response.code)
 
+    def test_no_content(self):
+        rv = tornado.concurrent.Future()
+        rv.set_result((204, ''))
+        checker = mock.Mock(return_value=rv)
+        with mock.patch.object(handlers.HTTPServiceHandler, 'CHECKERS', [checker]):
+            response = self.fetch('/http/no-content/80/status')
+            self.assertEqual(204, response.code)
+
     def test_haproxy_server_state(self):
         rv = tornado.concurrent.Future()
         rv.set_result((200, b'OK'))


### PR DESCRIPTION
We've seen several people who are having trouble because tornado 4.5.3 won't send an HTTP 204 if anything has been written to the body of the response (even an empty string) -- see https://github.com/tornadoweb/tornado/blob/v6.0.3/tornado/web.py#L1126

However, even if the healthcheck returns an empty body, this gets converted into an empty string in hacheck, which the base handler class tries to write into its response, which makes tornado mad.