### PR TITLE
include outbound request queue size in /status

### DIFF
--- a/hacheck/handlers.py
+++ b/hacheck/handlers.py
@@ -39,6 +39,13 @@ class StatusHandler(tornado.web.RequestHandler):
         stats = {}
         stats['cache'] = cache.get_stats()
         stats['uptime'] = time.time() - self.settings['start_time']
+
+        http_client = tornado.httpclient.AsyncHTTPClient(
+            io_loop=tornado.ioloop.IOLoop.current(),
+            max_clients=config.config['max_clients'],
+        )
+        stats['outbound_request_queue_size'] = len(http_client.queue)
+
         self.set_status(200)
         self.write(stats)
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -48,6 +48,7 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual('application/json; charset=UTF-8', response.headers['Content-Type'])
         result = json.loads(response.body.decode('utf-8'))
         self.assertGreater(result['uptime'], 0.0)
+        self.assertEqual(result['outbound_request_queue_size'], 0)
 
     def test_status_count(self):
         response = self.fetch('/status/count')


### PR DESCRIPTION
I also tested this by curling the crap out of the check endpoint so that it started queueing requests and then curling `/status`.