### PR TITLE
Run multiple hacheck processes on a host

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -218,7 +218,7 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
     def test_option_parsing(self):
         with nested(
             mock.patch('sys.argv', ['ignorethis', '-c', self.config_file.name, '--spool-root', 'foo']),
-            mock.patch.object(tornado.ioloop.IOLoop, 'instance'),
+            mock.patch('hacheck.main.IOLoop'),
             mock.patch.object(cache, 'configure'),
             mock.patch.object(main, 'get_app'),
             mock.patch.object(spool, 'configure')) \


### PR DESCRIPTION
(SMTSTK-239) This runs multiple copies of hacheck on a host to try to
resolve issues with hacheck getting overloaded and timing out.  We use
SO_REUSEPORT to allow the processes to run on the same port and use the
kernel as a load balancer.

We can't use the old method of starting the ioloop thing, because that doesn't work with the forking; so instead we move all the IOLoop calls after the fork and just call `.current()`